### PR TITLE
Only trigger on default defaultMaxSockets value

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,8 +5,8 @@ var https = require('https');
 var url = require('url');
 
 function agent(options) {
-	// if defaultMaxSockets is Infinity - then we should use default agent
-	if (http.Agent.defaultMaxSockets === Infinity) {
+	// if defaultMaxSockets is not default 5 - then we should use default agent
+	if (http.Agent.defaultMaxSockets !== 5) {
 		return undefined;
 	}
 

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ Returns instance of HTTP/HTTPS agent, based on `options`.
 
 This what `agent` could return:
 
- * `undefined`, if http.Agent.defaultMaxSockets is `Infinity`
+ * `undefined`, if http.Agent.defaultMaxSockets is not `5`
  * `agent.httpAgent`, if `options.protocol === 'http:'` (`agent.httpsAgent` otherwise)
  * New instance of HTTPS agent with `options`, if they contains any of [tls options](http://nodejs.org/api/tls.html#tls_tls_connect_options_callback)
 


### PR DESCRIPTION
If user explicitly set defaultMaxSockets to own number (like 32) - we should not bother him.

//cc @sindresorhus
